### PR TITLE
duplicate channels creation with private permission bug-fix #1

### DIFF
--- a/src/discordTools/SetupGuildCategory.js
+++ b/src/discordTools/SetupGuildCategory.js
@@ -1,20 +1,14 @@
-const Discord = require('discord.js');
-
 const DiscordTools = require('../discordTools/discordTools.js');
 
 module.exports = async (client, guild) => {
     const instance = client.getInstance(guild.id);
 
-    let category = undefined;
-    if (instance.channelId.category !== null) {
-        category = DiscordTools.getCategoryById(guild.id, instance.channelId.category);
-    }
+    let category = DiscordTools.getCategoryByName(guild.id, 'openAIAssistant');
     if (category === undefined) {
         category = await DiscordTools.addCategory(guild.id, 'openAIAssistant');
-        instance.channelId.category = category.id;
-        client.setInstance(guild.id, instance);
+        client.log('INFO', `Category created for guild id: ${guild.id}`);
     }
-
-    client.log('INFO', `Category created for guild id: ${guild.id}`);
+    instance.channelId.category = category.id;
+    client.setInstance(guild.id, instance);
     return category;
 };

--- a/src/discordTools/SetupGuildChannels.js
+++ b/src/discordTools/SetupGuildChannels.js
@@ -4,35 +4,21 @@ module.exports = async (client, guild, category) => {
     await addTextChannel('commands', 'commands', client, guild, category);
     await addTextChannel('teamchat', 'teamchat', client, guild, category);
     await addTextChannel('settings', 'settings', client, guild, category);
-    client.log('INFO', `Channels created for guild id: ${guild.id}`);
 };
 
 async function addTextChannel(name, idName, client, guild, parent) {
     const instance = client.getInstance(guild.id);
-
-    let channel = undefined;
-    if (instance.channelId[idName] !== null) {
-        channel = DiscordTools.getTextChannelById(guild.id, instance.channelId[idName]);
-    }
+    let channel = DiscordTools.getTextChannelByName(guild.id, idName);
     if (channel === undefined) {
         channel = await DiscordTools.addTextChannel(guild.id, name);
-        instance.channelId[idName] = channel.id;
-        client.setInstance(guild.id, instance);
-
         try {
             channel.setParent(parent.id);
         }
         catch (e) {
             client.log('ERROR',`Could not set parent for channel: ${channel.id}`, 'error');
         }
+        client.log('INFO', `Created channel '${idName}' for guild id: ${guild.id}`);
     }
-
-    if (instance.firstTime) {
-        try {
-            channel.setParent(parent.id);
-        }
-        catch (e) {
-            client.log('ERROR',`Could not set parent for channel: ${channel.id}`, 'error');
-        }
-    }
+    instance.channelId[idName] = channel.id;
+    client.setInstance(guild.id, instance);
 }

--- a/src/discordTools/discordTools.js
+++ b/src/discordTools/discordTools.js
@@ -54,8 +54,7 @@ module.exports = {
                 channel = guild.channels.cache.get(channelId);
             }
             catch (e) {
-                Client.client.log(Client.client.intlGet(null, 'errorCap'),
-                    Client.client.intlGet(null, 'couldNotFindChannel', { channel: channelId }), 'error');
+                Client.client.log('ERROR', `Could not find channel: ${channelId}`, 'error');
             }
 
             if (channel && channel.type === Discord.ChannelType.GuildText) {

--- a/src/handlers/permissionHandler.js
+++ b/src/handlers/permissionHandler.js
@@ -29,19 +29,15 @@ module.exports = {
 
         const category = await DiscordTools.getCategoryById(guild.id, instance.channelId.category);
 
-        await category.permissionOverwrites.edit(
-            instance.role === null ? guild.roles.everyone.id : instance.role, {
-            ViewChannel: true
-        });
+        await category.permissionOverwrites.edit(guild.roles.everyone.id, { ViewChannel: true });
 
         for (const [name, id] of Object.entries(instance.channelId)) {
-            if (name !== 'commands' && name !== 'teamchat') continue;
-
-            const channel = DiscordTools.getTextChannelById(guild.id, id);
-            await channel.permissionOverwrites.edit(
-                instance.role === null ? guild.roles.everyone.id : instance.role, {
-                SendMessages: true
-            });
+            if(name === 'category') continue;
+            let channel = DiscordTools.getTextChannelById(guild.id, id);
+            if(!channel) channel = DiscordTools.getTextChannelByName(guild.id, name);
+            
+            // client.log('INFO', JSON.stringify({ instanceChannelId: id, fetchedId: channel?.id }));
+            if(channel) await channel.permissionOverwrites.edit(guild.roles.everyone.id, { SendMessages: true });
         }
     },
 }

--- a/src/structures/DiscordBot.js
+++ b/src/structures/DiscordBot.js
@@ -91,18 +91,13 @@ class DiscordBot extends Discord.Client {
 
         let category = await require('../discordTools/SetupGuildCategory')(this, guild);
         await require('../discordTools/SetupGuildChannels')(this, guild, category);
-        // if (firstTime) {
-        //     await PermissionHandler.removeViewPermission(this, guild);
-        // }
-        // else {
-        //     await PermissionHandler.resetPermissions(this, guild);
-        // }
 
         // await require('../discordTools/SetupSettingsMenu')(this, guild);
-
-        instance.firstTime = false;
-        // if (firstTime) await PermissionHandler.resetPermissions(this, guild);
-
+        
+        if (firstTime) {
+            await PermissionHandler.resetPermissions(this, guild);
+            instance.firstTime = false;
+        }
         this.setInstance(guild.id, instance);
     }
 


### PR DESCRIPTION
Added guard rails around channel creation and resetting the channel permissions to view and can write by everyone only during the 1st `instance.json` creation.